### PR TITLE
Dont die on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Influxus [![GoDoc](https://godoc.org/github.com/vlad-doru/influxus?status.svg)](https://godoc.org/github.com/vlad-doru/influxus)
 ===
 
-Golang Hook for the [Logrus](https://github.com/Sirupsen/logrus) logging library, in order to output logs to [InfluxDB](https://influxdata.com/).
+Golang Hook for the [Logrus](https://github.com/sirupsen/logrus) logging library, in order to output logs to [InfluxDB](https://influxdata.com/).
 
 Usage
 ---
@@ -16,7 +16,7 @@ go get github.com/vlad-doru/influxus
 ```go
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/influxdata/influxdb/client/v2"
 	"github.com/vlad-doru/influxus"
 )

--- a/example/example.go
+++ b/example/example.go
@@ -3,7 +3,7 @@ package main
 import (
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/influxdata/influxdb/client/v2"
 	"github.com/vlad-doru/influxus"
 )

--- a/influxus.go
+++ b/influxus.go
@@ -79,7 +79,7 @@ func (hook *Hook) spawnBatchHandler() {
 	}
 	err = hook.config.Client.Write(batch)
 	if err != nil {
-		logrus.Fatalf("Could not write batch of points to InfluxDB: %v", err)
+		logrus.Errorf("Could not write batch of points to InfluxDB: %v", err)
 	}
 	// After we tried to write the batch we spawn a new batch handler.
 	go hook.spawnBatchHandler()

--- a/influxus.go
+++ b/influxus.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	influx "github.com/influxdata/influxdb/client/v2"
 )
 


### PR DESCRIPTION
This is a logging hook, and I don't want my whole application to go down if, for whatever reason, a log message couldn't be written to InfluxDB.

This change merely downgrades the `Fatalf` to `Errorf`, letting you know that there was a problem without killing your whole application.

In addition, this fixes the reference to `sirupsen` per `logrus`'s README.